### PR TITLE
`src` folder include on deploy

### DIFF
--- a/.bin/copy.js
+++ b/.bin/copy.js
@@ -7,7 +7,6 @@ const destination = 'deploy';
 
 const excludedFiles = [
     destination,
-    'src',
     'node_modules',
     'git-source',
     '.git',


### PR DESCRIPTION
- **Stylesheets and scripts**
When minified scripts or files are used, the original files must also be included in the theme folder.